### PR TITLE
remove usused functions

### DIFF
--- a/elm/Widget/Book.elm
+++ b/elm/Widget/Book.elm
@@ -9,11 +9,6 @@ type alias Model =
     Book
 
 
-init : Book -> ( Model, Cmd msg )
-init book =
-    ( book, Cmd.none )
-
-
 subscriptions : Model -> Sub Msg
 subscriptions _ =
     Sub.none

--- a/elm/Widget/BookSearch.elm
+++ b/elm/Widget/BookSearch.elm
@@ -22,11 +22,6 @@ initialModel =
     }
 
 
-init : Model -> ( Model, Cmd msg )
-init model =
-    ( model, Cmd.none )
-
-
 subscriptions : Model -> Sub Msg
 subscriptions _ =
     Sub.none


### PR DESCRIPTION
After splitting the widgets from `Main`, the two `init` functions inside the submodules are unused.
Moreover, their presence could be tricky as one may expect they are triggered at initialization (while it isn't)